### PR TITLE
Switch to using empty() rather than count()

### DIFF
--- a/includes/admin-reports/edit_attendee_record.php
+++ b/includes/admin-reports/edit_attendee_record.php
@@ -674,7 +674,7 @@ function edit_attendee_record() {
 							</fieldset>
 						</form></td>
 					<td  width="50%" valign="top">
-						<?php if (count($additional_attendees) > 0) { ?> 
+						<?php if (!empty($additional_attendees)) { ?> 
 						<h4>
 							<?php _e('Additional Attendees', 'event_espresso'); ?>
 						</h4>


### PR DESCRIPTION
Simple fix for an warning reported here: https://eventespresso.com/topic/edit-attendee-data-warning-line-677/

`$additional_attendees` may be null, which then throws a warning.